### PR TITLE
Conditional expressions with `cond`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ However, there's two other notation conventions that abandon this exception: Pol
 ```
 ...and the second one the other way around...
 ```
-y x ·
+(y, x)·
 ```
 These two conventions are characteristic to two families of programming languages: Lisps and Forths. Lisps use parentheses to denote function expressions' beginnings and ends, fundamentally making each function expression a list of tokens, hence the name Lisp: list processor...
 ```
@@ -56,8 +56,8 @@ At that point you should... simply follow the instruction, really. You can view 
 - `unquote/1`, which takes one s-expression as an argument and weaves it (for evaluation) into its surrounding quote experssion (usable only in `quote/1`),[^3]
 - `define/2`, which takes one identifier and one s-expression as arguments and makes it so that past that point, every instance of the identifier will be replaced with the (previously evaluated) s-expression.[^4]
 - `dis/1`, which takes a single s-expression as an argument and, without evaluating it, outputs its disassembled RPN microcode representation,
-- ~~`lambda/2`, which takes one list of identifiers and one s-expression as arguments and creates a lambda abstraction (anonymous function) using the identifiers from the first argument as its parameters and the s-expression as the function body~~[^5]
-- ~~`cond/n`, which takes an arbitrary number `n` of `(X Y)` pairs as arguments, where `X` is an expression that evaluates to a boolean value and `Y` is an s-expression. The interpreter will make its way through the `n` pairs and stop at the first one whose `X` evaluates to `True`, then evaluate `Y`.~~[^5]
+- `cond/n`, which takes an arbitrary number `n` of `(COND EXPR)` pairs as arguments, where `COND` is an expression that evaluates to a boolean value and `EXPR` is an expression. The interpreter will make its way through each pairs evaluate the `EXPR` of the first pair whose `COND` evaluates to True,
+- ~~`lambda/2`, which takes one list of identifiers and one s-expression as arguments and creates a lambda abstraction (anonymous function) using the identifiers from the first argument as its parameters and the s-expression as the function body.~~[^5]
 
 Enter `end`, `(end)`, or an empty line to exit the REPL gracefully.
 

--- a/src/native.py
+++ b/src/native.py
@@ -77,7 +77,7 @@ def atomq(vm):
 
 def nilq(vm):
     el = vm.stack.pop()
-    vm.stack.append(el == None)
+    vm.stack.append(el is None)
 
 def cons(vm):
     a = vm.stack.pop()

--- a/src/ops.py
+++ b/src/ops.py
@@ -13,6 +13,8 @@ OP_FIND = 3
 OP_START_ARGS = 4
 OP_UP_DIS = 5
 OP_DOWN_DIS = 6
+OP_JUMP = 7
+OP_JIF = 8
 
 # Documentation syntax:
 #
@@ -59,7 +61,18 @@ def opUpDis(vm):
     vm.optable = DISOPTABLE
     return 1
 
-OPTABLE = [opAtom, opCall, opDefine, opFind, opStartArgs, opUpDis]
+# OP_JUMP/1
+# Advances the PC by the value of the first positional argument.
+def opJump(vm):
+    return vm.pcval(1)
+
+# OP_JIF/1 (1)
+# Jumps to the first positional argument if the top of the stack is false.
+def opJif(vm):
+    if not vm.stack.pop():
+        return vm.pcval(1)
+    return 2
+
 
 # These are the disassembly versions of each of the VM's opcodes. They will be executed
 # instead of their default counterparts above when up into disassembly mode with `OP_UP_DIS`.
@@ -89,8 +102,17 @@ def disUpDis(vm):
     print(f"{vm.pc:03} -- OP_UP_DIS")
     return 1
 
+def disJump(vm):
+    print(f"{vm.pc:03} -- OP_JUMP   {vm.pcval(1)}")
+    return 2
+
+
+def disJif(vm):
+    print(f"{vm.pc:03} -- OP_JIF    {vm.pcval(1)}")
+    return 2
+
 # OP_DOWN_DIS/0
-# Makes the VM end disassembling if reaches 0. This is the only opcode that does not have
+# Makes the VM end disassembling if vm.disstate reaches 0. This is the only opcode that does not have
 # two optable-dependent variants -- there is no logical way in which we could encounter
 # an `OP_DOWN_DIS` outside of disassembly mode.
 def disDownDis(vm):
@@ -101,4 +123,5 @@ def disDownDis(vm):
         print(f"{vm.pc:03} -- OP_DOWN_DIS")
     return 1
 
-DISOPTABLE = [disAtom, disCall, disDefine, disFind, disStartArgs, disUpDis, disDownDis]
+OPTABLE = [opAtom, opCall, opDefine, opFind, opStartArgs, opUpDis, disDownDis, opJump, opJif]
+DISOPTABLE = [disAtom, disCall, disDefine, disFind, disStartArgs, disUpDis, disDownDis, disJump, disJif]

--- a/src/vm.py
+++ b/src/vm.py
@@ -43,7 +43,7 @@ class VM:
         self.pc = 0
         self.stack = []
         length = len(self.code)
-        while self.pc != length:
+        while self.pc < length:
             skip = self.optable[self.pcval()](self) # cool, huh? no internal opcode branching needed!
             self.pc += skip
 


### PR DESCRIPTION
This implements the Lisp language structure `cond`, which takes a list of pairs `(COND EXPR)` as arguments and evaluates to the first `EXPR` whose corresponding `COND` is true. We utilise backpatching and implement new opcodes `OP_JUMP` and `OP_JIF` (jump if false) to make this possible.