### PR TITLE
Implement `lambda/2` (and `lambda/1`)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # awrwydr
-Awrwydr is a toy McCarthian Lisp-like with a unique backend.
+...is a toy McCarthian Lisp-like with a unique backend.
 
 Do
 ```
-python path/to/src/awrwydr.py
+python3 path/to/src/awrwydr.py
 ```
 to enter the REPL.
 
@@ -25,7 +25,7 @@ However, there's two other notation conventions that abandon this exception: Pol
 ```
 ·(x, y)
 ```
-...and the second one the other way around...
+...and the second one the other way around[^1]...
 ```
 (y, x)·
 ```
@@ -38,8 +38,8 @@ These two conventions are characteristic to two families of programming language
 4 3 * 2 +
 ```
 
-### Troi yr awrwydr[^1]
-The observant reader might notice that PN and RPN[^2] versions of function expressions seem to always be mirror versions of themselves, with the latter ones being rid of parentheses. This is exactly Awrwydr's backend is based on!
+### Troi yr awrwydr[^2]
+The observant reader might notice that PN and RPN[^3] versions of function expressions seem to always be mirror versions of themselves, with the latter ones being rid of parentheses. This is exactly Awrwydr's backend is based on!
 
 The interpreter reads in a single line of some Lisp-like input. The parser makes its way through it, emitting reversed expressions in the correct order and a small stack-based virtual machine interprets them! This is done in the most simplistic, brain-dead manner possible, though there are some special Lisp constructs that can't simply be translated atom by atom and require some further care from the parser.
 
@@ -53,15 +53,15 @@ Enter an s-expression!
 ```
 At that point you should... simply follow the instruction, really. You can view supported in-built functions in both `Vm.__init__` (src/vm.py) and `Parser.__init__` (src/parser.py). Apart from those, there are two additional language constructs, not represented as function calls in the final VM microcode:
 - `quote/1`, which takes one s-expression as an argument and simply returns it as data. Identifiers are not resolved and are represented using Python strings,
-- `unquote/1`, which takes one s-expression as an argument and weaves it (for evaluation) into its surrounding quote experssion (usable only in `quote/1`),[^3]
-- `define/2`, which takes one identifier and one s-expression as arguments and makes it so that past that point, every instance of the identifier will be replaced with the (previously evaluated) s-expression.[^4]
+- `unquote/1`, which takes one s-expression as an argument and weaves it (for evaluation) into its surrounding quote experssion (usable only in `quote/1`),[^4]
+- `define/2`, which takes one identifier and one s-expression as arguments and makes it so that past that point, every instance of the identifier will be replaced with the (previously evaluated) s-expression.[^5]
 - `dis/1`, which takes a single s-expression as an argument and, without evaluating it, outputs its disassembled RPN microcode representation,
 - `cond/n`, which takes an arbitrary number `n` of `(COND EXPR)` pairs as arguments, where `COND` is an expression that evaluates to a boolean value and `EXPR` is an expression. The interpreter will make its way through each pairs evaluate the `EXPR` of the first pair whose `COND` evaluates to True,
-- ~~`lambda/2`, which takes one list of identifiers and one s-expression as arguments and creates a lambda abstraction (anonymous function) using the identifiers from the first argument as its parameters and the s-expression as the function body.~~[^5]
+- `lambda/2`, which takes one list of identifiers and one s-expression as arguments and creates a lambda abstraction (anonymous function) using the identifiers from the first argument as its parameters and the s-expression as the function body.
 
 Enter `end`, `(end)`, or an empty line to exit the REPL gracefully.
 
-All errors are reported within Python's exception system --- perhaps when all other important features are implemented I'll look to making a more competent error system.
+All errors are reported within Python's exception system — perhaps when all other important features are implemented I'll look to making a more competent error system.
 
 ## Questions
 ### What's src/prelude.lisp?
@@ -69,11 +69,11 @@ It serves both as a future[^6] test and a way to import some basic functionality
 ### What does the project's name mean? How do you pronounce it?
 It's pronounced something close to "hour-wedder" in English and it means "hourglass" in Welsh. I chose it to reflect the manner of PN-to-RPN translation used in this parser (reversal, like the turning of an hourglass).
 ### Why choose Python as the implementation language?
-Python trades performance for ease and speed of development - in the case of a toy interpreter, I value the latter deeply and don't really care about the prior.
+Python trades performance for ease and speed of development — in the case of a toy interpreter, I value the latter deeply and don't really care about the prior.
 
+[^1]: That is not to say that reverse Polish notation specifically has the arguments stand in reverse order or else you'll offend the computer science Gods; it all depends on definitions. That could have been `(x, y)·`, but I chose the reverse order to illustrate the reversing nature of the interpreter.
 [^1]: Welsh for "turning the hourglass \[upside down\]"
 [^2]: Short for Polish notation and reverse Polish notation
-[^3]: Which means `(quote (1 (unquote (+ 1 1)) 3))` is equivalent to `(quote (1 2 3))`.
+[^3]: For example, `(quote (1 (unquote (+ 1 1)) 3))` is equivalent to `(quote (1 2 3))`.
 [^4]: All this is just the long way to say `define/2` is used to define variables.
-[^5]: Not yet implemented!
-[^6]: Because not only does the interpreter not know yet how to import files, it doesn't know all the constructs used in the prelude (like `lambda` or `cond`).
+[^5]: Because not only does the interpreter not know yet how to import files, it doesn't know all the constructs used in the prelude (like `lambda` or `cond`).

--- a/src/awrwydr.py
+++ b/src/awrwydr.py
@@ -24,3 +24,5 @@ while True:
         break
     
     vm.run(parser.parse(lexer.lex(code)))
+    if vm.size() > 0:
+        print(f":: {vm.stack.pop()}\n")

--- a/src/cons.py
+++ b/src/cons.py
@@ -4,7 +4,6 @@ class Cons:
         self.cdr = cdr
 
     def __repr__(self):
-        # return f"({' '.join([str(el) for el in self])})"
         result = '('
         obj = self
         while True:
@@ -32,7 +31,6 @@ class Cons:
         return reversed(list(self.__iter__()))
 
     # Append a value to the end of the linked list.
-    # TODO: this should probably be rewritten
     def append(self, value):
         if self.car is None and value is not None:
             self.car = value
@@ -43,10 +41,6 @@ class Cons:
         else:
             self.cdr.append(value)
 
-    # Recursive in true functional fashion!
     def __len__(self):
-        if self.cdr is None:
-            return 1
-        else:
-            return 1 + len(self.cdr)
+        return len(list(self.__iter__()))
     

--- a/src/lambdaobj.py
+++ b/src/lambdaobj.py
@@ -1,0 +1,6 @@
+# This class describes a lambda object; i.e. an expression
+# with parameters (`params`).
+class Lambda:
+    def __init__(self, params, code):
+        self.params = params # a list of strings (names of parameters)
+        self.code = code     # executable VM microcode

--- a/src/lex.py
+++ b/src/lex.py
@@ -8,26 +8,31 @@ class Lexer:
     def lex(self, code):
         self.__init__() # just for good measure
         self.code = code
-        result = self.expr()
-        if self.cursor != len(code):
-            raise Exception("trailing expressions past a single s-expression")
-        return result
+        start = self.advance()
+        if start != '(':
+            return start
+        return self.expr(start)
 
-    def expr(self):
-        lexeme = self.advance()
+    def expr(self, lexeme):
+        if self.isAtEnd(): raise Exception("unexpected end of input")
+
         if lexeme == '(':
-            result = cons.Cons(self.expr(), None)
-            while self.curr() != ')':
-                result.append(self.expr())
+            result = cons.Cons(None, None)
+            while True:
+                lexeme = self.advance()
+                if lexeme == ')': break
+                result.append(self.expr(lexeme))
+
                 if self.isAtEnd(): raise Exception("unterminated s-expression")
-            self.cursor += 1
+
+            # self.cursor += 1
             return result
 
         elif lexeme == ')':
             raise Exception("unexpected closing paren `)`")
 
         else:
-            return lexeme # return lexeme parsed into atomic Python literal
+            return lexeme
 
     def curr(self):
         """Returns the character currently being inspected."""

--- a/src/native.py
+++ b/src/native.py
@@ -21,7 +21,7 @@ def add(vm):
             raise Exception("`+/n`: invalid argument type")
         args.append(el)
 
-    vm.stack.append(reduce(lambda a, b: a+b, args, 0))
+    vm.push(reduce(lambda a, b: a+b, args))
 
 def sub(vm):
     size = vm.argstarts.pop()
@@ -32,7 +32,7 @@ def sub(vm):
             raise Exception("`-/n`: invalid argument type")
         args.append(el)
 
-    vm.stack.append(reduce(lambda a, b: a-b, args, 0))
+    vm.push(reduce(lambda a, b: a-b, args))
 
 def mul(vm):
     size = vm.argstarts.pop()
@@ -43,7 +43,7 @@ def mul(vm):
             raise Exception("`*/n`: invalid argument type")
         args.append(el)
 
-    vm.stack.append(reduce(lambda a, b: a*b, args, 1))
+    vm.push(reduce(lambda a, b: a*b, args))
 
 def div(vm):
     size = vm.argstarts.pop()
@@ -54,7 +54,7 @@ def div(vm):
             raise Exception("`//n`: invalid argument type")
         args.append(el)
 
-    vm.stack.append(reduce(lambda a, b: a/b, args, 1))
+    vm.push(reduce(lambda a, b: a/b, args))
 
 def list(vm):
     size = vm.argstarts.pop()
@@ -64,34 +64,34 @@ def list(vm):
         args.append(el)
 
     args.reverse() # :/
-    vm.stack.append(reduce(lambda a, b: Cons(b, a), args, None))
+    vm.push(reduce(lambda a, b: Cons(b, a), args, None))
 
 def eqq(vm):
     a = vm.stack.pop()
     b = vm.stack.pop()
-    vm.stack.append(a == b)
+    vm.push(a == b)
 
 def atomq(vm):
     el = vm.stack.pop()
-    vm.stack.append(type(el) is int or type(el) is str)
+    vm.push(type(el) is int or type(el) is str)
 
 def nilq(vm):
     el = vm.stack.pop()
-    vm.stack.append(el is None)
+    vm.push(el is None)
 
 def cons(vm):
     a = vm.stack.pop()
     b = vm.stack.pop()
-    vm.stack.append(Cons(a, b))
+    vm.push(Cons(a, b))
 
 def car(vm):
     el = vm.stack.pop()
     if not type(el) is Cons:
         raise Exception("Invalid type for internal function `car`")
-    vm.stack.append(el.car)
+    vm.push(el.car)
 
 def cdr(vm):
     el = vm.stack.pop()
     if not type(el) is Cons:
         raise Exception("Invalid type for internal function `cdr`")
-    vm.stack.append(el.cdr)
+    vm.push(el.cdr)

--- a/src/vm.py
+++ b/src/vm.py
@@ -1,12 +1,14 @@
-from ops import *
+import ops
 import native
+from lambdaobj import *
+
 
 # Our stack-based VM! It operates on only five opcodes, all defined
 # in ops.py. Other than that it relies on native functions (native.py)
 # for all of its internal behavior.
 
 class VM:
-    def __init__(self):
+    def __init__(self, defs={}):
         self.stack = []
         self.argstarts = []
         # Each (key, value) pair corresponds to
@@ -25,11 +27,11 @@ class VM:
             "car": native.car,
             "cdr": native.cdr,
         }
-        self.defs = {} # definitions added with `define/2`
+        self.defs = defs # definitions added with `define/2` as well as lambda arguments
 
         self.code = None
         self.pc = 0
-        self.optable = OPTABLE
+        self.optable = ops.OPTABLE
         self.disstate = 0
 
     def pcval(self, offset=0):
@@ -37,6 +39,9 @@ class VM:
 
     def size(self):
         return len(self.stack)
+
+    def push(self, val):
+        self.stack.append(val)
 
     def run(self, code):
         self.code = code
@@ -46,6 +51,3 @@ class VM:
         while self.pc < length:
             skip = self.optable[self.pcval()](self) # cool, huh? no internal opcode branching needed!
             self.pc += skip
-
-        if self.size() > 0:
-            print(f":: {self.stack.pop()}\n")


### PR DESCRIPTION
This implements lambdas, or anonymous functions as literals. The syntax for constructing one is:
- (if given at least one parameter) `(lambda (ARG1 ARG2 ... ARGN) EXPR)`
- (if given no parameters) `(lambda EXPR)`

The second one in some ways acts like a thunk; a saved reference to a value that could be, for example, costly to evaluate.

```
>> (define factorial (lambda (n) (cond ((eq? 0 n) 1) (true (* n (factorial (- n 1)))))))
>> (define something-costly (lambda (factorial 1000000)))
>> something-costly
:: <lambdaobj.Lambda object at 0x102825280>
>> (do-some-stuff-with something-costly)
```
To evaluate a lambda with some arguments (or without them), call it like an in-built function: `(NAME ARG1 ARG2 ... ARGN)`